### PR TITLE
feat(sales): adicionar entities Sale e SaleItem, Value Objects para C…

### DIFF
--- a/root/src/Ambev.DeveloperEvaluation.Domain/Ambev.DeveloperEvaluation.Domain.csproj
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/Ambev.DeveloperEvaluation.Domain.csproj
@@ -10,7 +10,6 @@
     <Folder Include="Exceptions\" />
     <Folder Include="Repositories\" />
     <Folder Include="Events\" />
-    <Folder Include="ValueObjects\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/root/src/Ambev.DeveloperEvaluation.Domain/Common/ValueObject.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/Common/ValueObject.cs
@@ -1,0 +1,35 @@
+﻿namespace Ambev.DeveloperEvaluation.Domain.Common
+{
+    //Classe que uso para comparar objetos por valor
+    public abstract class ValueObject
+    {
+        protected abstract IEnumerable<object> GetEqualityComponents();
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj.GetType() != GetType())
+                return false;
+
+            var other = (ValueObject)obj;
+            return GetEqualityComponents().SequenceEqual(other.GetEqualityComponents());
+        }
+
+        public override int GetHashCode()
+        {
+            return GetEqualityComponents()
+                .Aggregate(0, (hash, obj) => hash ^ (obj?.GetHashCode() ?? 0));
+        }
+
+        public static bool operator ==(ValueObject a, ValueObject b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a is null || b is null) return false;
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(ValueObject a, ValueObject b)
+        {
+            return !(a == b);
+        }
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.Domain/Entities/Sale.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/Entities/Sale.cs
@@ -1,0 +1,79 @@
+﻿using Ambev.DeveloperEvaluation.Common.Validation;
+using Ambev.DeveloperEvaluation.Domain.Common;
+using Ambev.DeveloperEvaluation.Domain.Validation;
+using Ambev.DeveloperEvaluation.Domain.ValueObjects;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Ambev.DeveloperEvaluation.Domain.Entities
+{
+    public class Sale : BaseEntity
+    {
+        public string SaleNumber { get; private set; }
+        public DateTime SaleDate { get; private set; }
+        public Guid CustomerId { get; private set; }
+        [NotMapped]
+        public Customer Customer { get; private set; }
+        public Guid BranchId { get; private set; }
+        [NotMapped]
+        public Branch Branch { get; private set; }
+        public ICollection<SaleItem> Items { get; private set; }
+        public bool IsCancelled { get; private set; }
+
+
+        public Sale(string saleNumber, DateTime saleDate, Customer customer, Branch branch)
+        {
+            SaleNumber = saleNumber;
+            SaleDate = saleDate;
+            CustomerId = customer.CustomerId;
+            Customer = customer;
+            BranchId = branch.BranchId;
+            Branch = branch;
+            Items = new List<SaleItem>();
+            IsCancelled = false;
+        }
+
+        private Sale() { }
+
+        public void AddItem(Product product, int quantity, decimal unitPrice)
+        {
+            var existingItem = Items.FirstOrDefault(i => i.Product.ProductId == product.ProductId);
+
+            if (existingItem != null)
+            {
+                existingItem.UpdateQuantity(existingItem.Quantity + quantity);
+            }
+            else
+            {
+                var newItem = new SaleItem(Id, product, quantity, unitPrice);
+                Items.Add(newItem);
+            }
+        }
+
+        public void RemoveItem(Guid productId)
+        {
+            var itemToRemove = Items.FirstOrDefault(i => i.ProductId == productId);
+            if (itemToRemove != null)
+            {
+                Items.Remove(itemToRemove);
+            }
+        }
+
+        public decimal TotalAmount => Items.Sum(i => i.TotalAmount);
+
+        public void Cancel()
+        {
+            IsCancelled = true;
+        }
+
+        public ValidationResultDetail Validate()
+        {
+            var validator = new SaleValidator();
+            var result = validator.Validate(this);
+            return new ValidationResultDetail
+            {
+                IsValid = result.IsValid,
+                Errors = result.Errors.Select(o => (ValidationErrorDetail)o)
+            };
+        }
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
@@ -1,0 +1,62 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Common;
+using Ambev.DeveloperEvaluation.Domain.ValueObjects;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Ambev.DeveloperEvaluation.Domain.Entities
+{
+    public class SaleItem : BaseEntity
+    {
+        public Guid SaleId { get; private set; }
+        public Sale? Sale { get; private set; }
+        public Guid ProductId { get; private set; }
+        [NotMapped]
+        public Product Product { get; private set; }
+        public int Quantity { get; private set; }
+        public decimal UnitPrice { get; private set; }
+        public decimal Discount { get; private set; }
+        public decimal TotalAmount => (Quantity * UnitPrice) - Discount;
+
+        public SaleItem(Guid saleId, Product product, int quantity, decimal unitPrice)
+        {
+            SaleId = saleId;
+            ProductId = product.ProductId;
+            Product = product;
+            Quantity = quantity > 0 ? quantity : throw new ArgumentException("Quantity must be greater than zero.");
+            UnitPrice = unitPrice > 0 ? unitPrice : throw new ArgumentException("Unit price must be greater than zero.");
+            Discount = CalculateDiscount(quantity, unitPrice);
+        }
+
+        private SaleItem() { }
+
+        private decimal CalculateDiscount(int quantity, decimal unitPrice)
+        {
+            if (quantity > 20)
+            {
+                throw new InvalidOperationException("Cannot sell more than 20 identical items.");
+            }
+
+            if (quantity >= 10 && quantity <= 20)
+            {
+                return quantity * unitPrice * 0.20m;
+            }
+            else if (quantity >= 4)
+            {
+                return quantity * unitPrice * 0.10m;
+            }
+
+            return 0;
+        }
+
+        public void UpdateQuantity(int newQuantity)
+        {
+            if (newQuantity <= 0)
+            {
+                throw new ArgumentException("Quantity must be greater than zero.");
+            }
+
+            Quantity = newQuantity;
+            Discount = CalculateDiscount(newQuantity, UnitPrice);
+        }
+    }
+}
+

--- a/root/src/Ambev.DeveloperEvaluation.Domain/Validation/SaleValidator.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/Validation/SaleValidator.cs
@@ -1,0 +1,14 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.Domain.Validation;
+
+public class SaleValidator : AbstractValidator<Sale>
+{
+    public SaleValidator()
+    {
+        RuleFor(sale => sale.SaleNumber).NotEmpty();
+        RuleFor(sale => sale.CustomerId).NotEmpty().NotEqual(Guid.Empty);
+        RuleFor(sale => sale.BranchId).NotEmpty().NotEqual(Guid.Empty);
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.Domain/ValueObjects/Branch.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/ValueObjects/Branch.cs
@@ -1,0 +1,23 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Common;
+
+namespace Ambev.DeveloperEvaluation.Domain.ValueObjects
+{
+    public class Branch : ValueObject
+    {
+        public Guid BranchId { get; private set; }
+        public string Name { get; private set; }
+        public string Address { get; private set; }
+
+        public Branch(Guid branchId, string name, string address)
+        {
+            BranchId = branchId;
+            Name = name;
+            Address = address;
+        }
+
+        protected override IEnumerable<object> GetEqualityComponents()
+        {
+            yield return BranchId;
+        }
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.Domain/ValueObjects/Customer.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/ValueObjects/Customer.cs
@@ -1,0 +1,21 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Common;
+
+namespace Ambev.DeveloperEvaluation.Domain.ValueObjects
+{
+    public class Customer : ValueObject
+    {
+        public Guid CustomerId { get; private set; }
+        public string Name { get; private set; }
+
+        public Customer(Guid customerId, string name)
+        {
+            CustomerId = customerId;
+            Name = name;
+        }
+
+        protected override IEnumerable<object> GetEqualityComponents()
+        {
+            yield return CustomerId;
+        }
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.Domain/ValueObjects/Product.cs
+++ b/root/src/Ambev.DeveloperEvaluation.Domain/ValueObjects/Product.cs
@@ -1,0 +1,21 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Common;
+
+namespace Ambev.DeveloperEvaluation.Domain.ValueObjects
+{
+    public class Product : ValueObject
+    {
+        public Guid ProductId { get; private set; }
+        public string Title { get; private set; }
+
+        public Product(Guid productId, string title)
+        {
+            ProductId = productId;
+            Title = title;
+        }
+
+        protected override IEnumerable<object> GetEqualityComponents()
+        {
+            yield return ProductId;
+        }
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
+++ b/root/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
@@ -9,6 +9,8 @@ namespace Ambev.DeveloperEvaluation.ORM;
 public class DefaultContext : DbContext
 {
     public DbSet<User> Users { get; set; }
+    public DbSet<Sale> Sales { get; set; }
+    public DbSet<SaleItem> SaleItems { get; set; }
 
     public DefaultContext(DbContextOptions<DefaultContext> options) : base(options)
     {

--- a/root/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
+++ b/root/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ambev.DeveloperEvaluation.ORM.Mapping;
+
+public class SaleConfiguration : IEntityTypeConfiguration<Sale>
+{
+    public void Configure(EntityTypeBuilder<Sale> builder)
+    {
+        builder.ToTable("Sales");
+
+        builder.HasKey(u => u.Id);
+        builder.Property(u => u.Id).HasColumnType("uuid").HasDefaultValueSql("gen_random_uuid()");
+
+        builder.Property(u => u.CustomerId).HasColumnType("uuid").HasColumnName("CustomerId");
+        builder.Property(u => u.BranchId).HasColumnType("uuid").HasColumnName("BranchId");
+
+        builder.HasMany(u => u.Items)
+           .WithOne(i => i.Sale)
+           .HasForeignKey(i => i.SaleId)
+           .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
+++ b/root/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ambev.DeveloperEvaluation.ORM.Mapping;
+
+public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
+{
+    public void Configure(EntityTypeBuilder<SaleItem> builder)
+    {
+        builder.ToTable("SaleItems");
+
+        builder.HasKey(i => i.Id);
+        builder.Property(i => i.Id).HasColumnType("uuid").HasDefaultValueSql("gen_random_uuid()");
+
+        builder.Property(u => u.ProductId).HasColumnType("uuid").HasColumnName("ProductId");
+
+        builder.Property(i => i.SaleId).HasColumnType("uuid");
+        builder.HasOne(i => i.Sale)
+            .WithMany(s => s.Items)
+            .HasForeignKey(i => i.SaleId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/root/src/Ambev.DeveloperEvaluation.WebApi/Migrations/20250212203210_SaleMigration.Designer.cs
+++ b/root/src/Ambev.DeveloperEvaluation.WebApi/Migrations/20250212203210_SaleMigration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Ambev.DeveloperEvaluation.ORM;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Ambev.DeveloperEvaluation.WebApi.Migrations
 {
     [DbContext(typeof(DefaultContext))]
-    partial class DefaultContextModelSnapshot : ModelSnapshot
+    [Migration("20250212203210_SaleMigration")]
+    partial class SaleMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/root/src/Ambev.DeveloperEvaluation.WebApi/Migrations/20250212203210_SaleMigration.cs
+++ b/root/src/Ambev.DeveloperEvaluation.WebApi/Migrations/20250212203210_SaleMigration.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ambev.DeveloperEvaluation.WebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class SaleMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Sales_Branch_BranchId",
+                table: "Sales");
+
+            migrationBuilder.DropTable(
+                name: "Branch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sales_BranchId",
+                table: "Sales");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Branch",
+                columns: table => new
+                {
+                    BranchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Address = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Branch", x => x.BranchId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sales_BranchId",
+                table: "Sales",
+                column: "BranchId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Sales_Branch_BranchId",
+                table: "Sales",
+                column: "BranchId",
+                principalTable: "Branch",
+                principalColumn: "BranchId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/root/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/SaleTests.cs
+++ b/root/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/SaleTests.cs
@@ -1,0 +1,42 @@
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Unit.Domain.Entities.TestData;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Domain.Entities;
+
+public class SaleTests
+{
+
+    [Fact(DisplayName = "Validation should pass for valid sale data")]
+    public void Given_ValidSaleData_When_Validated_Then_ShouldReturnValid()
+    {
+        // Arrange
+        var sale = SaleTestData.GenerateValidSale();
+
+        // Act
+        var result = sale.Validate();
+
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact(DisplayName = "Validation should fail for invalid sale data")]
+    public void Given_InvalidSaleData_When_Validated_Then_ShouldReturnInvalid()
+    {
+        // Arrange
+        var sale = new Sale(
+            string.Empty,
+            DateTime.Now,
+            SaleTestData.GenerateInvalidCustomer(),
+            SaleTestData.GenerateInvalidBranch()
+        );
+
+        // Act
+        var result = sale.Validate();
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Errors);
+    }
+}

--- a/root/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/TestData/SaleTestData.cs
+++ b/root/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/TestData/SaleTestData.cs
@@ -1,0 +1,42 @@
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.ValueObjects;
+using Bogus;
+
+namespace Ambev.DeveloperEvaluation.Unit.Domain.Entities.TestData;
+
+public static class SaleTestData
+{
+    public static readonly Faker<Sale> SaleFake = new Faker<Sale>()
+        .CustomInstantiator(f => new Sale(
+            saleNumber: $"{f.Random.Number(1, 1000)}-{f.Random.Number(1001, 999999999)}",
+            DateTime.Now,
+            GenerateValidCustomer(),
+            GenerateValidBranch()
+        ));
+
+    public static Sale GenerateValidSale()
+    {
+        return SaleFake.Generate();
+    }
+
+
+    public static Customer GenerateValidCustomer()
+    {
+        return new Customer(Guid.NewGuid(), "Thiago Borges");
+    }
+
+    public static Customer GenerateInvalidCustomer()
+    {
+        return new Customer(Guid.Empty, "Foo Bar");
+    }
+
+    public static Branch GenerateValidBranch()
+    {
+        return new Branch(Guid.NewGuid(), "Filial do Thiago", "Fica em São Paulo mesmo");
+    }
+
+    public static Branch GenerateInvalidBranch()
+    {
+        return new Branch(Guid.Empty, "Branch Foo Bar", "Address Branch Foo Bar");
+    }
+}


### PR DESCRIPTION
- Criado Customer, Branch e Product como Value Objects para representar entidades externas.
- Adicionado NotMapped nos Value Objects para evitar criação de tabelas no banco.
- Modificada a entidade Sale para armazenar apenas CustomerId e BranchId, mantendo os dados do cliente e da filial desacoplados.
- Ajustada configuração do EF Core (SaleConfiguration) para garantir persistência correta dos IDs.
- Implementada estratégia para buscar e preencher os Value Objects após recuperação da venda.
- Adicionado os dois primeiros testes GREEN para Sales